### PR TITLE
Query/post array instead of assembled query string

### DIFF
--- a/wp-mendeley.php
+++ b/wp-mendeley.php
@@ -97,17 +97,17 @@ if (!class_exists("MendeleyPlugin")) {
 			   // check if access token should be refreshed
 			   $expires_at = $this->settings['oauth2_expires_at'];
 			   if ($expires_at < (time() - 200)) {
-			      $callback_url = admin_url('options-general.php?').http_build_query(array('page' => 'wp-mendeley.php', 'access_mendeleyPluginOAuth2' => 'true'));
+			      $callback_url = admin_url('options-general.php?') . http_build_query(array('page' => 'wp-mendeley.php', 'access_mendeleyPluginOAuth2' => 'true'));
 			      // retrieve new authorization token
 			      $curl = curl_init(OAUTH2_REQUEST_TOKEN_ENDPOINT);
 			      curl_setopt($curl, CURLOPT_POST, true);
  			      curl_setopt($curl, CURLOPT_POSTFIELDS, array(
-                                  'grant_type' => 'refresh_token',
-                                  'refresh_token' => $this->settings['oauth2_refresh_token'],
-                                  'client_id' => $client_id,
-                                  'client_secret' => $client_secret,
-                                  'redirect_uri' => $callback_url
-                              ));
+			         'grant_type' => 'refresh_token',
+			         'refresh_token' => $this->settings['oauth2_refresh_token'],
+			         'client_id' => $client_id,
+			         'client_secret' => $client_secret,
+			         'redirect_uri' => $callback_url
+			      ));
 			      curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 		 	      // basic authentication ...
 			      curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . base64_encode($client_id . ':' . $client_secret)));
@@ -581,14 +581,14 @@ if (!class_exists("MendeleyPlugin")) {
 			}
 
 			$request_count = 500;
-                        $query_data = array( 'view' => 'all', 'order' => 'desc', 'sort' => 'created', 'limit' => $request_count);
-                        if( "$id" === "0") {
-                            $query_data['authored'] = 'true';
+			$query_data = array('view' => 'all', 'order' => 'desc', 'sort' => 'created', 'limit' => $request_count);
+			if( "$id" === "0") {
+			    $query_data['authored'] = 'true';
                         } else {
-                            $query_data['group_id'] = $id;
+			    $query_data['group_id'] = $id;
                         }
 
-			$url = "documents?" . http_build_query( $query_data);
+			$url = "documents?" . http_build_query($query_data);
 			$docarr = $this->sendAuthorizedRequest($url);
 			$mendeley_count = 0 + $headers["Mendeley-Count"];
 			if ($mendeley_count > $request_count) { // pagination ...
@@ -622,7 +622,7 @@ if (!class_exists("MendeleyPlugin")) {
 			}
 
 			$request_count = 500;
-			$url = "folders/$id/documents?" . http_build_query( array( 'limit' => $request_count, 'view' => 'all'));
+			$url = "folders/$id/documents?" . http_build_query(array('limit' => $request_count, 'view' => 'all'));
 			$docids = $this->sendAuthorizedRequest($url);
 			if (is_null($docids)) {
 				$docids = array(0 => $result->id);
@@ -1008,7 +1008,7 @@ if (!class_exists("MendeleyPlugin")) {
 							if ($slideshareUrl) {
 								//make a http request so you get authenticated to embed slideshares
 								$curl = curl_init();
-								curl_setopt($curl, CURLOPT_URL, "http://www.slideshare.net/api/oembed/2?" . http_build_query( array( 'url' => $urlitem , 'format' => 'json')));
+								curl_setopt($curl, CURLOPT_URL, "http://www.slideshare.net/api/oembed/2?" . http_build_query(array('url' => $urlitem , 'format' => 'json')));
 								curl_setopt($curl, CURLOPT_HEADER, false);
 								curl_setopt($curl, CURLOPT_HTTPHEADER, array('User-Agent: CURL'));
 								curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
@@ -1542,7 +1542,7 @@ if (!class_exists("MendeleyPlugin")) {
 		 */
 		function printAdminPage() {
 			$this->getOptions();
-			$callback_url = admin_url('options-general.php?') . http_build_query( array( 'page' => 'wp-mendeley.php', 'access_mendeleyPluginOAuth2' => 'true'));
+			$callback_url = admin_url('options-general.php?') . http_build_query(array('page' => 'wp-mendeley.php', 'access_mendeleyPluginOAuth2' => 'true'));
 			// check if any form data has been submitted and process it
 			if (isset($_POST['update_mendeleyPlugin'])) {
 				if (isset($_POST['debug'])) {
@@ -1597,7 +1597,7 @@ if (!class_exists("MendeleyPlugin")) {
 
 				$client_id = $this->settings['oauth2_client_id'];
                 		$client_secret = $this->settings['oauth2_client_secret'];
-				$auth_url = OAUTH2_AUTHORIZE_ENDPOINT . '?' . http_build_query( array( 'client_id' => $client_id, 'response_type' => 'code', 'scope' => 'all', 'redirect_uri' => $callback_url));
+				$auth_url = OAUTH2_AUTHORIZE_ENDPOINT . '?' . http_build_query(array('client_id' => $client_id, 'response_type' => 'code', 'scope' => 'all', 'redirect_uri' => $callback_url));
 				redirect($auth_url);
 				exit;
 			}
@@ -1617,12 +1617,12 @@ if (!class_exists("MendeleyPlugin")) {
 				   $curl = curl_init(OAUTH2_REQUEST_TOKEN_ENDPOINT);
 				   curl_setopt($curl, CURLOPT_POST, true);
 				   curl_setopt($curl, CURLOPT_POSTFIELDS, array(
-                                       'grant_type' = >'authorization_code',
-                                       'code' => $_GET['code'],
-                                       'client_id' => $client_id,
-                                       'client_secret' => $client_secret,
-                                       'redirect_uri' => $callback_url
-                                   ));
+				      'grant_type' = >'authorization_code',
+				      'code' => $_GET['code'],
+				      'client_id' => $client_id,
+				      'client_secret' => $client_secret,
+				      'redirect_uri' => $callback_url
+				   ));
 				   curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1);
 				   // basic authentication ...
 				   curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . base64_encode($client_id . ':' . $client_secret)));
@@ -1666,12 +1666,12 @@ if (!class_exists("MendeleyPlugin")) {
 			   $curl = curl_init(OAUTH2_REQUEST_TOKEN_ENDPOINT);
 			   curl_setopt($curl, CURLOPT_POST, true);
 			   curl_setopt($curl, CURLOPT_POSTFIELDS, array(
-                               'grant_type' => 'refresh_token',
-                               'refresh_token' => $this->settings['oauth2_refresh_token']
-                               'client_id' => $client_id,
-                               'client_secret' => $client_secret,
-                               'redirect_uri' => $callback_url
-                           ));
+			      'grant_type' => 'refresh_token',
+			      'refresh_token' => $this->settings['oauth2_refresh_token']
+			      'client_id' => $client_id,
+			      'client_secret' => $client_secret,
+			      'redirect_uri' => $callback_url
+			   ));
 			   curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1);
 		 	   // basic authentication ...
 			   curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . base64_encode($client_id . ':' . $client_secret)));

--- a/wp-mendeley.php
+++ b/wp-mendeley.php
@@ -97,11 +97,17 @@ if (!class_exists("MendeleyPlugin")) {
 			   // check if access token should be refreshed
 			   $expires_at = $this->settings['oauth2_expires_at'];
 			   if ($expires_at < (time() - 200)) {
-			      $callback_url = admin_url('options-general.php?page=wp-mendeley.php&access_mendeleyPluginOAuth2=true');
+			      $callback_url = admin_url('options-general.php?').http_build_query(array('page' => 'wp-mendeley.php', 'access_mendeleyPluginOAuth2' => 'true'));
 			      // retrieve new authorization token
 			      $curl = curl_init(OAUTH2_REQUEST_TOKEN_ENDPOINT);
 			      curl_setopt($curl, CURLOPT_POST, true);
- 			      curl_setopt($curl, CURLOPT_POSTFIELDS, 'grant_type=refresh_token&refresh_token='.urlencode($this->settings['oauth2_refresh_token']).'&client_id='.urlencode($client_id).'&client_secret='.urlencode($client_secret).'&redirect_uri='.urlencode($callback_url));
+ 			      curl_setopt($curl, CURLOPT_POSTFIELDS, array(
+                                  'grant_type' => 'refresh_token',
+                                  'refresh_token' => $this->settings['oauth2_refresh_token'],
+                                  'client_id' => $client_id,
+                                  'client_secret' => $client_secret,
+                                  'redirect_uri' => $callback_url
+                              ));
 			      curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 		 	      // basic authentication ...
 			      curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . base64_encode($client_id . ':' . $client_secret)));
@@ -575,10 +581,14 @@ if (!class_exists("MendeleyPlugin")) {
 			}
 
 			$request_count = 500;
-			$url = "documents?group_id=$id&view=all&order=desc&sort=created&limit=$request_count";
-			if ("$id" === "0") { // "own"
-			   $url = "documents?group_id=&authored=true&view=all&order=desc&sort=created&limit=$request_count";
-			}
+                        $query_data = array( 'view' => 'all', 'order' => 'desc', 'sort' => 'created', 'limit' => $request_count);
+                        if( "$id" === "0") {
+                            $query_data['authored'] = 'true';
+                        } else {
+                            $query_data['group_id'] = $id;
+                        }
+
+			$url = "documents?" . http_build_query( $query_data);
 			$docarr = $this->sendAuthorizedRequest($url);
 			$mendeley_count = 0 + $headers["Mendeley-Count"];
 			if ($mendeley_count > $request_count) { // pagination ...
@@ -612,7 +622,7 @@ if (!class_exists("MendeleyPlugin")) {
 			}
 
 			$request_count = 500;
-			$url = "folders/$id/documents?limit=$request_count&view=all";
+			$url = "folders/$id/documents?" . http_build_query( array( 'limit' => $request_count, 'view' => 'all'));
 			$docids = $this->sendAuthorizedRequest($url);
 			if (is_null($docids)) {
 				$docids = array(0 => $result->id);
@@ -998,7 +1008,7 @@ if (!class_exists("MendeleyPlugin")) {
 							if ($slideshareUrl) {
 								//make a http request so you get authenticated to embed slideshares
 								$curl = curl_init();
-								curl_setopt($curl, CURLOPT_URL, "http://www.slideshare.net/api/oembed/2?url=" . $urlitem . "&format=json");
+								curl_setopt($curl, CURLOPT_URL, "http://www.slideshare.net/api/oembed/2?" . http_build_query( array( 'url' => $urlitem , 'format' => 'json')));
 								curl_setopt($curl, CURLOPT_HEADER, false);
 								curl_setopt($curl, CURLOPT_HTTPHEADER, array('User-Agent: CURL'));
 								curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
@@ -1532,7 +1542,7 @@ if (!class_exists("MendeleyPlugin")) {
 		 */
 		function printAdminPage() {
 			$this->getOptions();
-			$callback_url = admin_url('options-general.php?page=wp-mendeley.php&access_mendeleyPluginOAuth2=true');
+			$callback_url = admin_url('options-general.php?') . http_build_query( array( 'page' => 'wp-mendeley.php', 'access_mendeleyPluginOAuth2' => 'true'));
 			// check if any form data has been submitted and process it
 			if (isset($_POST['update_mendeleyPlugin'])) {
 				if (isset($_POST['debug'])) {
@@ -1587,7 +1597,7 @@ if (!class_exists("MendeleyPlugin")) {
 
 				$client_id = $this->settings['oauth2_client_id'];
                 		$client_secret = $this->settings['oauth2_client_secret'];
-				$auth_url = OAUTH2_AUTHORIZE_ENDPOINT . "?client_id=$client_id&response_type=code&scope=all&redirect_uri=".urlencode($callback_url);
+				$auth_url = OAUTH2_AUTHORIZE_ENDPOINT . '?' . http_build_query( array( 'client_id' => $client_id, 'response_type' => 'code', 'scope' => 'all', 'redirect_uri' => $callback_url));
 				redirect($auth_url);
 				exit;
 			}
@@ -1606,7 +1616,13 @@ if (!class_exists("MendeleyPlugin")) {
 				   // retrieve full authorization token
 				   $curl = curl_init(OAUTH2_REQUEST_TOKEN_ENDPOINT);
 				   curl_setopt($curl, CURLOPT_POST, true);
-				   curl_setopt($curl, CURLOPT_POSTFIELDS, 'grant_type=authorization_code&code='.urlencode($_GET['code']).'&client_id='.urlencode($client_id).'&client_secret='.urlencode($client_secret).'&redirect_uri='.urlencode($callback_url));
+				   curl_setopt($curl, CURLOPT_POSTFIELDS, array(
+                                       'grant_type' = >'authorization_code',
+                                       'code' => $_GET['code'],
+                                       'client_id' => $client_id,
+                                       'client_secret' => $client_secret,
+                                       'redirect_uri' => $callback_url
+                                   ));
 				   curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1);
 				   // basic authentication ...
 				   curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . base64_encode($client_id . ':' . $client_secret)));
@@ -1649,7 +1665,13 @@ if (!class_exists("MendeleyPlugin")) {
 			   // retrieve new authorization token
 			   $curl = curl_init(OAUTH2_REQUEST_TOKEN_ENDPOINT);
 			   curl_setopt($curl, CURLOPT_POST, true);
-			   curl_setopt($curl, CURLOPT_POSTFIELDS, 'grant_type=refresh_token&refresh_token='.urlencode($this->settings['oauth2_refresh_token']).'&client_id='.urlencode($client_id).'&client_secret='.urlencode($client_secret).'&redirect_uri='.urlencode($callback_url));
+			   curl_setopt($curl, CURLOPT_POSTFIELDS, array(
+                               'grant_type' => 'refresh_token',
+                               'refresh_token' => $this->settings['oauth2_refresh_token']
+                               'client_id' => $client_id,
+                               'client_secret' => $client_secret,
+                               'redirect_uri' => $callback_url
+                           ));
 			   curl_setopt( $curl, CURLOPT_RETURNTRANSFER, 1);
 		 	   // basic authentication ...
 			   curl_setopt($curl, CURLOPT_HTTPHEADER, array('Authorization: Basic ' . base64_encode($client_id . ':' . $client_secret)));


### PR DESCRIPTION
Thanks for the great plugin.
While I was trying to understand, what is going on (looking into the 'own' type), I saw that the query strings are assembled through string concatenation with url_encode calls, and would like to suggest to use the [http_build_query](http://php.net/manual/en/function.http-build-query.php) function for that.
Also the curl_setopt with CURLOPT_POSTFIELDS accepts an array.
For me that improves readability and in the future it is easier to reuse the query args and extend them as required for certain api calls.
http_build_query is not compatible to php4 (requires php5)! So I am not sure how important that is for the plugin. You state that wordpress 4 is required (I cannot find the minimal php version for wordpress 4), but I think that using php4 nowadays is not recommended anyways.
Thanks for considering the contribution. Some more might follow..