### PR TITLE
MendeleyPlugin has a deprecated constructor

### DIFF
--- a/wp-mendeley.php
+++ b/wp-mendeley.php
@@ -67,9 +67,13 @@ if (!class_exists("MendeleyPlugin")) {
 		protected $options = null;
 		protected $error_message = "";
 		var $expandCounter = 0; // count expandables (in text output)
-		function MendeleyPlugin() { // constructor
+
+                /** constructor */
+		function __construct() {
 			$this->init();
 		}
+
+                /** initialize */
 		function init() {
 			$this->getOptions();
 			$this->initializeDatabase();


### PR DESCRIPTION
The Plugin class still had a constructor with the classname as function name (like in PHP 4)
->renamed to __construct
->this was done in version 1.1.2 for all other classes and their constructors