### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/mendeley-details-template.tpl
+++ b/mendeley-details-template.tpl
@@ -15,7 +15,7 @@
 <p>Tags:<blockquote>{tags}</blockquote></p>
 
 <p>URL: <a href="{url}">{url}</a></p>
-<p>DOI: <a href="http://dx.doi.org/{doi}">{doi}</a></p>
+<p>DOI: <a href="https://doi.org/{doi}">{doi}</a></p>
 <p>ISBN: {isbn}</p>
 
 <a href="{mendeley_url}">Reference on Mendeley.com</a></p>

--- a/readme.txt
+++ b/readme.txt
@@ -324,6 +324,9 @@ repository to upload bug fixes and other additions.
 
 == Change log ==
 
+= 1.2.0 (01.07.2018) =
+* hyperlink DOIs against preferred resolver, see https://www.doi.org/doi_handbook/3_Resolution.html#3.8
+
 = 1.1.20 (16.11.2017) =
 * added support for localization - currently mainly the abbreviations like "p." or "eds."
 

--- a/wp-mendeley.php
+++ b/wp-mendeley.php
@@ -1030,7 +1030,7 @@ if (!class_exists("MendeleyPlugin")) {
 				if (isset($doc->identifiers)) {
 				   if (isset($doc->identifiers->doi)) {
                                 	$atext = "doi:" . $doc->identifiers->doi;
-                                	$result .= ', <span class="wpmurl"><a target="_blank" href="http://dx.doi.org/' . $doc->identifiers->doi . 
+                                	$result .= ', <span class="wpmurl"><a target="_blank" href="https://doi.org/' . $doc->identifiers->doi . 
 						'"><span class="wpmurl' . $atext . '">' . $atext . '</span></a></span>';
                                    }
 				}


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all code that generates new DOI links.

Cheers!